### PR TITLE
Add setcap cmd at image level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1.5 (Unreleased)
+- Add setcap cmd on plugin file at container level
+
 ##  v1.1.4 (2022-01-03)
 - Support for optional SSL mode within init script
 - Support for optional kv-v2 engine within init script

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,6 @@ COPY --from=builder /plugin/LICENSE /
 COPY --from=builder /plugin/quorum-hashicorp-vault-plugin /vault/plugins/quorum-hashicorp-vault-plugin
 COPY --from=builder /plugin/scripts/* /usr/local/bin/
 
+RUN setcap cap_ipc_lock=+ep /vault/plugins/quorum-hashicorp-vault-plugin
+
 EXPOSE 8200


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines -->

## PR Description

Addition of the `setcap` cmd at Container level

Will avoid running it at the Pod level in k8s clusters and also fixes an issue in Azure environment

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.
